### PR TITLE
major algorithmic update to rsa_noise_ceiling.py

### DIFF
--- a/gsn/calc_shrunken_covariance.py
+++ b/gsn/calc_shrunken_covariance.py
@@ -6,9 +6,9 @@ from gsn.utilities import squish
 from gsn.calc_mv_gaussian_pdf import calc_mv_gaussian_pdf
 
 def calc_shrunken_covariance(data, 
-                           leaveout = 5, 
-                           shrinklevels = np.linspace(0,1,51), 
-                           wantfull = 0):
+                             leaveout = 5, 
+                             shrinklevels = np.linspace(0,1,51), 
+                             wantfull = 0):
     """
     mn, c, shrinklevel, nll = calc_shrunken_covariance(data,leaveout,shrinklevels,wantfull)
 
@@ -157,7 +157,9 @@ def calc_shrunken_covariance(data,
                                              wantomitexp = 1) 
 
         if err:
-            nll[p] = np.nan
+            # set to infinity instead of nan, since np.argmin doesn't
+            # handle nans well. 
+            nll[p] = np.inf 
             continue
         
         # calculate mean negative log likelihood (lower values mean higher probabilities)

--- a/gsn/rsa_noise_ceiling.py
+++ b/gsn/rsa_noise_ceiling.py
@@ -1,22 +1,35 @@
 import numpy as np
-from gsn.utilities import squish, posrect
+from gsn.utilities import squish, posrect, nanreplace, calc_cod
 from gsn.calc_shrunken_covariance import calc_shrunken_covariance
 from gsn.construct_nearest_psd_covariance import construct_nearest_psd_covariance
 import scipy.stats as stats
+from scipy.special import comb
 from scipy.spatial.distance import pdist
+import itertools
+from tqdm import tqdm
+import matplotlib.pyplot as plt
 
 def rsa_noise_ceiling(data,
                       wantverbose = True,
-                      rdmfun = lambda x: pdist(x.T,'correlation'),
-                      comparefun = lambda x,y: stats.pearsonr(x,y)[0],
-                      numsim = 20,
+                      rdmfun = lambda x: pdist(x.T, 'correlation'),
+                      comparefun = lambda x, y: stats.pearsonr(x, y)[0],
+                      wantfig = 1,
+                      ncsims = 50,
+                      ncconds = 50,
                       nctrials = None,
-                      shrinklevels = np.linspace(0,1,51),
+                      splitmode = 0,
+                      scs = np.arange(0, 2.1, 0.1),
+                      simchunk = 50,
+                      simthresh = 10,
+                      maxsimnum = 1000,
+                      shrinklevels = np.linspace(0, 1, 51),
                       mode = 0):
     """
-    nc, ncdist, results = rsa_noise_ceiling(data,rdmfun,comparefun,numsim,nctrials)
+    [nc, ncdist, results] = rsa_noise_ceiling(data,rdmfun,comparefun,ncsims,nctrials)
 
-    <data> is voxels x conditions x trials
+    <data> is voxels x conditions x trials. This indicates the measured
+      responses to different conditions on distinct trials. The number of 
+      trials must be at least 2.
     <wantverbose> (optional) is whether to print status statements. Default: 1.
     <rdmfun> (optional) is a function that constructs an RDM. Specifically,
       the function should accept as input a data matrix (e.g. voxels x conditions)
@@ -29,13 +42,63 @@ def rsa_noise_ceiling(data,
       that is returned by <rdmfun>) and output a scalar. 
       Default: lambda x,y: stats.pearsonr(x,y)[0], returning the Pearson
       correlation between the two RDMs.
-    <numsim> (optional) is the number of Monte Carlo simulations to run.
-      The final answer is computed as the median across simulations. Default: 20.
+    <wantfig> (optional) is
+      0 means do not make a figure
+      1 means plot a figure in a new figure window
+      A means write a figure to filename prefix A (e.g., '/path/to/figure'
+        will result in /path/to/figure.png being written)
+      Default: 1.
+    <ncsims> (optional) is the number of Monte Carlo simulations to run for
+      the purposes of estimating the RSA noise ceiling. The final answer 
+      is computed as the median across simulation results. Default: 50.
+    <ncconds> (optional) is the number of conditions to simulate in the Monte
+      Carlo simulations. In theory, the RSA noise ceiling estimate should be 
+      invariant to number of conditions simulated, but the higher the number,
+      the more stable/accurate the results. Default: 50.
     <nctrials> (optional) is the number of trials over which to average for
       the purposes of the noise ceiling estimate. For example, setting
       <nctrials> to 10 will result in the calculation of a noise ceiling 
       estimate for the case in which responses are averaged across 10 trials
       measured for each condition. Default: data.shape[2].
+    <splitmode> (optional) controls the way in which trials are divided
+      for the data reliability calculation. Specifically, <splitmode> is:
+      0 means use only the maximum split-half number of trials. In the case
+        of an odd number of trials T, we use floor(T/2).
+      1 means use numbers of trials increasing by a factor of 2 starting
+        at 1 and including the maximum split-half number of trials.
+        For example, if there are 10 trials total, we use [1 2 4 5].
+      2 means use the maximum split-half number of trials as well as half
+        of that number (rounding down if necessary). For example, if 
+        there are 11 trials total, we use [2 5].
+      The primary value of using multiple numbers of trials (e.g. options 
+      1 and 2) is to provide greater insight for the figure inspection that is
+      created. However, in terms of accuracy of RSA noise ceiling estimates,
+      option 0 should be fine (and will result in faster execution).
+      Default: 0.
+    <scs> (optional) controls the way in which the posthoc scaling factor
+      is determined. Specifically, <scs> is:
+      A where A is a vector of non-negative values. This specifies the
+        specific scale factors to evaluate. There is a trade-off between
+        speed of execution and the discretization/precision of the results.
+      Default: np.arange(0, 2.1, 0.1).
+    <simchunk> (optional) is the chunk size for the data-splitting and
+      model-based simulations. Default: 50, which indicates to perform 50 
+      simulations for each case, and then increment in steps of 50 if 
+      necessary to achieve <simthresh>. Must be 2 or greater.
+    <simthresh> (optional) is the value for the robustness metric that must
+      be exceeded in order to halt the data-splitting simulations. 
+      The lower this number, the faster the execution time, but the less 
+      accurate the results. Default: 10.
+    <maxsimnum> (optional) is the maximum number of simulations to perform
+      for the data-splitting simulations. Default: 1000.
+    <shrinklevels> (optional) is a non-empty vector (1 x F) of shrinkage fractions
+      (between 0 and 1 inclusive) to evaluate. For example, 0.8 means to
+      shrink values to 80  of their original size. Default: np.linspace(0,1,51).
+    <mode> (optional) is
+      0 means use the data-reliability method
+      1 means use no scaling.
+      2 means scale to match the un-regularized average variance
+      Default: 0.
 
     Use the GSN (generative modeling of signal and noise) method to estimate
     an RSA noise ceiling.
@@ -46,7 +109,7 @@ def rsa_noise_ceiling(data,
 
     Return:
       <nc> as a scalar with the noise ceiling estimate.
-      <ncdist> as 1 x <numsim> with the result of each simulation.
+      <ncdist> as 1 x <ncsims> with the result of each Monte Carlo simulation.
         Note that <nc> is simply the median of <ncdist>.
       <results> as a struct with additional details:
         mnN - the estimated mean of the noise (1 x voxels)
@@ -54,14 +117,27 @@ def rsa_noise_ceiling(data,
         mnS - the estimated mean of the signal (1 x voxels)
         cS  - the estimated covariance of the signal (voxels x voxels)
         cSb - the regularized estimated covariance of the signal (voxels x voxels).
-              this estimate reflects both a nearest-approximation and 
-              a post-hoc scaling, and is used in the Monte Carlo simulations.
+              This estimate reflects both a nearest-approximation and 
+              a post-hoc scaling that is designed to match the data reliability
+              estimate. It is this regularized signal covariance that is
+              used in the Monte Carlo simulations.
         rapprox - the correlation between the nearest-approximation of the 
                   signal covariance and the original signal covariance
+        sc - the post-hoc scaling factor that was selected
+        splitr - the data split-half reliability value that was obtained for the
+                 largest trial number that was evaluated. (We return the median
+                 result across the simulations that were conducted.)
+        ncsnr - the 'noise ceiling SNR' estimate for each voxel (1 x voxels).
+                This is, for each voxel, the std dev of the estimated signal
+                distribution divided by the std dev of the estimated noise
+                distribution. Note that this is computed on the originally
+                estimated signal covariance and not the regularized signal
+                covariance. Also, note that we apply positive rectification to 
+                the signal std dev (to prevent non-sensical negative ncsnr values).
 
     Example:
     data = np.random.randn(100,40,4) + 2*np.random.randn(100,40,4);
-    [nc,ncdist,results] = rsa_noise_ceiling(data)
+    [nc,ncdist,results] = rsa_noise_ceiling(data, splitmode = 1)
 
     internal inputs:
 
@@ -77,6 +153,12 @@ def rsa_noise_ceiling(data,
     ncond  = data.shape[1]
     ntrial = data.shape[2]
     
+    # deal with massaging inputs and sanity checks
+    assert ntrial >= 2, f"ntrial must be greater than or equal to 2. got: {ntrial}"
+    scs = np.unique(scs)
+    assert np.all(scs >= 0), f"all scs must be greater than or equal to 0. got: {scs}"
+    assert simchunk >= 2, f"simchunk must be greater than or equal to 2. got: {simchunk}"
+    
     ###### ESTIMATION #####
     
     # how many simulated trial averages to perform
@@ -88,7 +170,7 @@ def rsa_noise_ceiling(data,
         print('Estimating noise covariance...')
         
     # estimate noise covariance
-    mnN, cN, shrinklevelN, nllN = calc_shrunken_covariance(data = np.transpose(data,(2,0,1)),
+    mnN, cN, shrinklevelN, nllN = calc_shrunken_covariance(data = np.transpose(data, (2, 0, 1)),
                                                            shrinklevels = shrinklevels,
                                                            wantfull = 1)
     
@@ -97,7 +179,7 @@ def rsa_noise_ceiling(data,
         print('Estimating data covariance...')        
 
     # estimate data covariance
-    mnD, cD, shrinklevelD, nllD = calc_shrunken_covariance(data = np.mean(data,2).T,
+    mnD, cD, shrinklevelD, nllD = calc_shrunken_covariance(data = np.mean(data, 2).T,
                                                            shrinklevels = shrinklevels,
                                                            wantfull = 1)
     
@@ -107,46 +189,277 @@ def rsa_noise_ceiling(data,
 
     # estimate signal covariance
     mnS = mnD - mnN
-    cS  =  cD - cN/ntrial
+    cS  =  cD - cN / ntrial
     
     if wantverbose is True:
         print('done.\n')
         
-    ##### REGULARIZATION #####
+    # prepare some outputs
+    sd_noise = np.sqrt(np.diag(cN)) # std of the noise (1 x voxels)
+    sd_signal = np.sqrt(posrect(np.diag(cS))) # std of the signal (1 x voxels)
+    ncsnr = sd_signal / sd_noise # noise ceiling SNR (1 x voxels)
+    
+    ##### REGULARIZATION OF COVARIANCES #####
     
     if wantverbose is True:
-        print('Regularizing...')
+        print('Regularizing...\n')
 
     # calculate nearest approximation for the noise.
     # this is expected to be PSD already. however, small numerical issues
     # may occassionally arise. so, our strategy is to go ahead and
     # run it through the approximation, and to do a quick assertion to 
     # check sanity. note that we just overwrite cN.
-    cN,rapprox0 = construct_nearest_psd_covariance(cN)
-    assert(rapprox0 > 0.99)
+    cN, rapprox0 = construct_nearest_psd_covariance(cN)
+    assert rapprox0 > 0.99, f"Construct nearest psd covariance failed."
 
     # calculate nearest approximation for the signal.
     # this is the more critical case!
-    cSb,rapprox = construct_nearest_psd_covariance(cS)
+    cSb, rapprox = construct_nearest_psd_covariance(cS)
+    
+    # deal with scaling of the signal covariance matrix
+    if mode == 1:
+        
+        # do nothing
+        sc = 1
+        splitr = []
+        
+    elif mode == 2:
+        
+        # scale the nearest approximation to match the average variance 
+        # that is observed in the original estimate of the signal covariance.
+        
+        # notice the posrect to ensure non-negative scaling
+        sc = posrect(np.mean(np.diag(cS))) / np.mean(np.diag(cSb))
+        
+        # impose scaling and run it through 
+        # construct_nearest_psd_covariance.py for good measure
+        cSb, _ = construct_nearest_psd_covariance(cSb * sc)   
+        
+    elif mode == 0:
+        
+        if splitmode == 0:
+            
+            # use only the maximum split-half number of trials
+            # in the case of an odd number of trials T, we use floor(T/2).
+            splitnums = [np.floor(ntrial / 2)]
+            
+        elif splitmode == 1:
+            
+            # use numbers of trials increasing by a factor of 2 starting
+            # at 1 and including the maximum split-half number of trials
+            splitnums = list(np.unique(list(2 ** np.arange(0, np.floor(np.log2(ntrial / 2)) + 1)) + [np.floor(ntrial / 2)]))
+            
+        elif splitmode == 2:
+            
+            # use the maximum split-half number of trials as well as half
+            # of that number (rounding down if necessary). For example, if 
+            # there are 11 trials total, we use [2 5]
+            splitnums = np.array([np.floor(np.floor(ntrial / 2) / 2), np.floor(ntrial / 2)])
+            splitnums = list(splitnums[splitnums > 0])
+            
+        if wantverbose is True:
+            print('\tCalculating data split-half reliability...\n')
+            
+        # first, we need to figure out if we can do exhaustive combinations
+        doexhaustive = 1
+        combolist = dict()
+        validmatrix = dict()
+        
+        for nn in range(len(splitnums) - 1, -1, -1):
+            
+            # if the dimensionality seems too large, just get out
+            if comb(ntrial, splitnums[nn]) > 2 * simchunk:
+                doexhaustive = 0
+                break
+                
+            # calculate the full set of possibilities
+            combolist[nn] = np.array(list(itertools.combinations(np.arange(ntrial), int(splitnums[nn]))))
+            ncomb = combolist[nn].shape[0]
+            
+            validmatrix[nn] = np.zeros((ncomb, ncomb))
+            
+            for r in range(ncomb):
+                for c in range(ncomb):
+                    if c <= r: # this admits only the upper triangle as potentially valid
+                        continue 
+                    if len(np.intersect1d(combolist[nn][r], combolist[nn][c])) == 0:
+                        validmatrix[nn][r, c] = 1
+                        
+            # if the number of combinations to process is more than simchunk, just give up
+            if np.sum(validmatrix[nn]) > simchunk:
+                doexhaustive = 0
+                break
+        
+        # if it looks like we can do it exhaustively, do it!
+        if doexhaustive == 1:
+            
+            if wantverbose is True:
+                print('\tDoing exhaustive set of combinations...')
+            
+            # we will save only one single value with the ultimate result
+            datasplitr = np.zeros((len(splitnums),)) 
+            
+            for nn in range(len(splitnums)):
+                
+                ncomb = combolist[nn].shape[0]
+                temp = []
+                
+                for r in range(ncomb):
+                    for c in range(ncomb):
+                        if validmatrix[nn][r,c] == 1:
+                            temp.append(nanreplace(comparefun(rdmfun(np.mean(data[:, :, combolist[nn][r]], 2)),
+                                                              rdmfun(np.mean(data[:, :, combolist[nn][c]], 2)))))
+                            
+                datasplitr[nn] = np.median(temp)
+                
+            splitr = datasplitr[-1] # 1 x 1 with the result for the "most trials" data split case
+        
+        else: # otherwise, do the random-sampling approach
+            
+            if wantverbose is True:
+                print('\tDoing random-sampling approach...\n')
+            
+            iicur = 0        # current sim number
+            iimax = simchunk # current targeted max
 
-    # scale the nearest approximation to match the average variance 
-    # that is observed in the original estimate of the signal covariance.
-    if mode == 0:
-        sc = posrect(np.mean(np.diag(cS))) / np.mean(np.diag(cSb))  # notice the posrect to ensure non-negative scaling
-        cSb, _ = construct_nearest_psd_covariance(cSb * sc)   # impose scaling and run it through construct_nearest_psd_covariance.py for good measure
-    elif mode == 1:
-        pass
+            # empty matrix for simulation results
+            datasplitr = np.zeros((len(splitnums), iimax))
+
+            while 1:
+
+                for nn in range(len(splitnums)):
+                    for si in range(iicur, iimax):
+                        temp = np.random.permutation(ntrial)
+
+                        dataA = data[:, :, temp[:int(splitnums[nn])]]
+
+                        dataB = data[:, :, temp[int(splitnums[nn])+np.arange(splitnums[nn]).astype(int)]]
+
+                        datasplitr[nn,si] = nanreplace(comparefun(rdmfun(np.mean(dataA, axis = 2)),
+                                                                  rdmfun(np.mean(dataB, axis = 2))))
+
+                temp = datasplitr
+                robustness = np.mean(np.abs(np.median(temp, axis=1)) / ((stats.iqr(temp, axis=1) / 2) / np.sqrt(temp.shape[1])))
+                
+                if robustness > simthresh:
+                    if wantverbose is True:
+                        print('\t...procedure ended due to robustness threshold exceeded.')
+                    break
+
+                iicur = iimax
+                iimax += simchunk
+
+                if iimax > maxsimnum:
+                    if wantverbose is True:
+                        print('\t...procedure ended due to reaching maxsimnum.')
+                    break
+                    
+                # append more zeros so we can keep going
+                datasplitr = np.hstack((datasplitr, np.zeros((len(splitnums), simchunk))))
+
+            # scalar with the median result for the "most trials" data split case
+            splitr = np.median(datasplitr[-1, :]) 
+            
+        # done with data split reliability
+        if wantverbose is True:
+            print('\tdone with data split-half reliability.\n')
+            
+        # calculate model-based split reliability
+        if wantverbose is True:
+            print('\tCalculating model split-half reliability...')
+            
+        iicur = 0        # current sim number
+        iimax = simchunk # current targeted max
+        
+        # empty matrix for results
+        modelsplitr = np.zeros((len(scs), len(splitnums), iimax))
+        
+        # precompute
+        tempcS = np.zeros((cSb.shape[0], cSb.shape[1], len(scs)))
+            
+        for sci in range(len(scs)):
+            temp, _ = construct_nearest_psd_covariance(cSb * scs[sci])
+            tempcS[:, :, sci] = temp
+            
+        while 1:
+            robustness = np.zeros((len(scs),))
+            for sci in tqdm(range(len(scs))):
+                for nn in range(len(splitnums)):
+                    for si in range(iicur, iimax):
+                        signal = np.random.multivariate_normal(np.squeeze(mnS), tempcS[:, :, sci], size = ncconds) # cond x voxels
+                        noise = np.random.multivariate_normal(np.squeeze(mnN), cN / splitnums[nn], size = ncconds * 2) # 2*cond x voxels
+                        measurementA = signal + noise[:ncconds] # cond x voxels
+                        measurementB = signal + noise[ncconds:] # cond x voxels
+                        modelsplitr[sci, nn, si] = nanreplace(comparefun(rdmfun(measurementA.T), 
+                                                                         rdmfun(measurementB.T)))
+                                                
+                temp = modelsplitr[sci]
+                robustness[sci] = np.mean(np.abs(np.median(temp, axis=1)) / ((stats.iqr(temp, axis=1) / 2) / np.sqrt(temp.shape[1])))
+            
+            robustness = np.mean(robustness)
+            
+            if robustness > simthresh:
+                if wantverbose is True:
+                    print('\t...procedure ended due to robustness threshold exceeded.')
+                break
+                
+            iicur = iimax
+            iimax += simchunk
+            
+            if iimax > maxsimnum:
+                if wantverbose is True:
+                    print('\t...procedure ended due to reaching maxsimnum.')
+                break
+                        
+            # append more zeros so we can keep going
+            modelsplitr = np.concatenate((modelsplitr, np.zeros((len(scs), len(splitnums), simchunk))), axis = 2)
+                        
+        if wantverbose is True:
+            print('\tdone with model split-half reliability.\n')
+            
+        # calculate R^2 between model-based results and the data results and find the max
+        if wantverbose is True:
+            print('\tFinding best model...')
+                
+        model_median = np.median(modelsplitr, axis = 2)
+        data_median = np.tile(np.median(datasplitr.reshape(-1 ,1), axis = 1), 
+                              (len(scs), 1))
+        
+        # scales x 1
+        R2s = calc_cod(model_median, data_median, dim = 1, wantgain = 0, wantmeansub = 0)
+        bestii = np.argmax(R2s)
+        sc = scs[bestii]
+        
+        # impose scaling and run it through construct_nearest_psd_covariance
+        # for good measure
+        cSb, _ = construct_nearest_psd_covariance(cSb * sc)
+            
+        # if the data split r is higher than all of the model split r, 
+        # we should warn the user.
+        temp = np.median(modelsplitr[:,-1],axis = 1)
+        
+        if splitr > np.max(temp):
+            print(f'\twarning: the empirical data split r seems to be out of range of the model. something may be wrong; results may be inaccurate. consider increasing the <scs> input.')
+            
+        # do a sanity check on the smoothness of the R2 results.
+        # if they appear to be non-smooth, we should warn the user
+        if len(R2s) >= 4:
+            temp = calc_cod(np.convolve(R2s, np.array([1,1,1])/3, 'valid'),
+                            R2s[1:-1])
+            
+        if temp < 90:
+            print(f'\twarning: the R2 values appear to be non-smooth (smooth function explains only {temp}% variance). something may be wrong; results may be inaccurate. consider increasing simchunk, simthresh, and/or maxsimnum')
 
     if wantverbose is True:
-        print('done.\n')
+        print('\tdone.\n')
         
     ##### SIMULATIONS #####
-    if wantverbose is True:
-        print('Performing Monte Carlo simulations...')
+    # if wantverbose is True:
+    #     print('Performing Monte Carlo simulations...')
         
     # perform Monte Carlo simulations
-    ncdist = np.zeros((numsim,))
-    for rr in range(numsim):
+    ncdist = np.zeros((ncsims,))
+    for rr in range(ncsims):
         
         signal = np.random.multivariate_normal(np.squeeze(mnS), cSb, size = ncond) # cond x voxels
         noise = np.random.multivariate_normal(np.squeeze(mnN), cN, size = ncond * nctrials) # ncond*nctrials x voxels
@@ -155,15 +468,30 @@ def rsa_noise_ceiling(data,
         ncdist[rr] = comparefun(rdmfun(signal.T), rdmfun(measurement.T))
         
     if wantverbose is True:
+        print('...done with regularization of covariances.\n')
+        
+        
+    ##### MONTE CARLO SIMULATIONS FOR RSA NOISE CEILING #####
+    
+    if wantverbose is True:
+        print('Performing Monte Carlo simulations...')
+    
+    # output variable for simulations
+    ncdist = np.zeros((ncsims,))
+    
+    # perform monte carlo sims
+    for rr in range(ncsims):
+        signal = np.random.multivariate_normal(np.squeeze(mnS), cSb, size = ncconds)          # ncconds x voxels
+        noise = np.random.multivariate_normal(np.squeeze(mnN), cN / nctrials, size = ncconds) # ncconds x voxels
+        measurement = signal + noise                                                          # ncconds x voxels
+        ncdist[rr] = nanreplace(comparefun(rdmfun(signal.T), 
+                                           rdmfun(measurement.T)))
+        
+    if wantverbose is True:
         print('done.\n')
 
     ##### FINISH UP #####
     
-    # if comparefun ever outputs NaN, set these cases to 0.
-    # for example, you might be correlating an all-zero signal
-    # with some data, which may result in NaN.
-    ncdist[np.isnan(ncdist)] = 0
-
     # compute median across simulations
     nc = np.median(ncdist)
 
@@ -173,6 +501,121 @@ def rsa_noise_ceiling(data,
                'mnS': mnS,
                'cS': cS,
                'cSb': cSb,
-               'rapprox': rapprox}
-                                                        
-    return nc,ncdist,results
+               'rapprox': rapprox,
+               'sc': sc,
+               'splitr': splitr,
+               'ncsnr': ncsnr}
+    
+    ##### MAKE A FIGURE #####
+    
+    if mode is 0 and wantfig is not 0:
+    
+        if wantverbose is True:
+            print('Creating figure...')
+
+        ax = plt.figure(figsize=(48,40)).subplot_mosaic(
+                    """
+                    AAAAABBBBBCCCCC
+                    DDDDDEEEEEFFFFF
+                    GGGGGGG.HHHHHHH
+                    GGGGGGG.HHHHHHH
+                    """
+                    ) 
+
+        titleft = 36
+        labelft = 24
+
+        ax['A'].hist(np.squeeze(mnS), facecolor='#442cb4', align = 'left')
+        ax['A'].set_ylabel('Frequency',fontsize=labelft)
+        ax['A'].set_title('Mean of Signal',fontsize=titleft)
+        ax['A'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        mx = np.max(np.abs(cS.reshape(-1)))
+        if mx == 0:
+            mx = 1
+
+        im = ax['B'].imshow(cS, clim=(-mx, mx), cmap = 'viridis')
+        cb = plt.colorbar(im, ax = ax['B'])
+        cb.ax.tick_params(labelsize=labelft-2)
+        ax['B'].set_title('Covariance of Signal',fontsize=titleft)
+        ax['B'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        mx = np.max(np.abs(cSb.reshape(-1)))
+        if mx == 0:
+            mx = 1
+
+        im = ax['C'].imshow(cSb, clim=(-mx, mx), cmap = 'viridis')
+        cb = plt.colorbar(im, ax = ax['C'])
+        cb.ax.tick_params(labelsize=labelft-2)
+        ax['C'].set_title('Regularized and scaled',fontsize=titleft)
+        ax['C'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        ax['D'].hist(np.squeeze(mnN), facecolor='#442cb4', align = 'left')
+        ax['D'].set_ylabel('Frequency',fontsize=labelft)
+        ax['D'].set_title('Mean of Noise',fontsize=titleft)
+        ax['D'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        mx = np.max(np.abs(cN.reshape(-1)))
+        if mx == 0:
+            mx = 1
+
+        im = ax['E'].imshow(cN, clim=(-mx, mx), cmap = 'viridis')
+        cb = plt.colorbar(im, ax = ax['E'])
+        cb.ax.tick_params(labelsize=labelft-2)
+        ax['E'].set_title('Covariance of Noise',fontsize=titleft)
+        ax['E'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        ax['F'].hist(np.squeeze(ncsnr), facecolor='#442cb4', align = 'left')
+        ax['F'].set_ylabel('Frequency',fontsize=labelft)
+        ax['F'].set_title('Noise ceiling SNR',fontsize=titleft)
+        ax['F'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        hs = []
+        for sci in range(len(scs)):
+            md0 = np.median(datasplitr.reshape(-1, 1), axis = 1)
+            sd0 = (stats.iqr(datasplitr.reshape(-1, 1), axis = 1)) / 2
+            
+        nlines = len(scs)
+        cm = plt.cm.viridis(np.linspace(0, 1, nlines))
+
+        for sci in range(len(scs)):
+            md0 = np.median(modelsplitr[sci],axis=1) # 1 x n
+            se0 = (stats.iqr(modelsplitr[sci],axis=1)/2) / np.sqrt(modelsplitr.shape[2]) # 1 x n
+        
+            if scs[sci] == sc:
+                lw0 = 8
+                mark0 = 'o'
+            else:
+                lw0 = 4
+                mark0 = 'x'
+
+            ax['G'].plot(np.squeeze(splitnums), md0, f'{mark0}-',linewidth = lw0, color=cm[sci], markersize=16)
+
+        md0 = np.median(datasplitr.reshape(-1, 1), axis = 1)
+        sd0 = (stats.iqr(datasplitr.reshape(-1, 1), axis = 1)) / 2
+        se0 = sd0 / np.sqrt(datasplitr.reshape(-1, 1).shape[1])
+        ax['G'].plot(np.squeeze(splitnums), md0, 'k-', linewidth = 8, zorder=100, marker = 'o', markersize=20, markeredgecolor = 'k', markerfacecolor = 'none')
+        ax['G'].set_xlim([np.min(splitnums)-1, np.max(splitnums)+1])
+        ax['G'].set_xlabel('Number of trials in each split',fontsize=labelft)
+        ax['G'].set_ylabel('Similarity (comparefun output)',fontsize=labelft)
+        
+        if doexhaustive is 1:
+            ax['G'].set_title(f"Data (ALL sims); Model ({modelsplitr.shape[2]} sims); splitr={round(splitr,3)}",fontsize=titleft)
+        else:
+            ax['G'].set_title(f"Data ({datasplitr.shape[1]} sims); Model ({modelsplitr.shape[2]} sims); splitr={round(splitr,3)}",fontsize=titleft)
+        ax['G'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        ax['H'].plot(scs, R2s, 'r-', marker = 'o', markeredgecolor='r', markerfacecolor='none', markersize=20)
+        ax['H'].plot([sc, sc], [np.nanmin(R2s), np.nanmax(R2s)], 'k', linewidth = 8)
+        ax['H'].set_xlabel('Scaling factor',fontsize=labelft)
+        ax['H'].set_ylabel('R^2 between model and data (%)',fontsize=labelft)
+        ax['H'].set_title(f"rapprox={round(rapprox,2)}, sc = {round(sc,2)}, nc = {round(nc,3)}, +/- {round(stats.iqr(ncdist)/2/np.sqrt(len(ncdist)),3)}",fontsize=titleft)
+        ax['H'].tick_params(axis='both', which='major', labelsize=labelft-2)
+
+        if wantfig is not 1: 
+            plt.savefig(wantfig, facecolor = 'white')
+            
+        if wantverbose is True:
+            print('done.\n')
+        
+    return nc, ncdist, results

--- a/gsn/rsa_noise_ceiling.py
+++ b/gsn/rsa_noise_ceiling.py
@@ -339,7 +339,7 @@ def rsa_noise_ceiling(data,
                                                                   rdmfun(np.mean(dataB, axis = 2))))
 
                 temp = datasplitr
-                robustness = np.mean(np.abs(np.median(temp, axis=1)) / ((stats.iqr(temp, axis=1) / 2) / np.sqrt(temp.shape[1])))
+                robustness = np.mean(np.abs(np.median(temp, axis = 1)) / ((stats.iqr(temp, axis = 1) / 2) / np.sqrt(temp.shape[1])))
                 
                 if robustness > simthresh:
                     if wantverbose is True:
@@ -394,7 +394,7 @@ def rsa_noise_ceiling(data,
                                                                          rdmfun(measurementB.T)))
                                                 
                 temp = modelsplitr[sci]
-                robustness[sci] = np.mean(np.abs(np.median(temp, axis=1)) / ((stats.iqr(temp, axis=1) / 2) / np.sqrt(temp.shape[1])))
+                robustness[sci] = np.mean(np.abs(np.median(temp, axis = 1)) / ((stats.iqr(temp, axis = 1) / 2) / np.sqrt(temp.shape[1])))
             
             robustness = np.mean(robustness)
             
@@ -436,7 +436,7 @@ def rsa_noise_ceiling(data,
             
         # if the data split r is higher than all of the model split r, 
         # we should warn the user.
-        temp = np.median(modelsplitr[:,-1],axis = 1)
+        temp = np.median(modelsplitr[:, -1], axis = 1)
         
         if splitr > np.max(temp):
             print(f'\twarning: the empirical data split r seems to be out of range of the model. something may be wrong; results may be inaccurate. consider increasing the <scs> input.')
@@ -444,7 +444,7 @@ def rsa_noise_ceiling(data,
         # do a sanity check on the smoothness of the R2 results.
         # if they appear to be non-smooth, we should warn the user
         if len(R2s) >= 4:
-            temp = calc_cod(np.convolve(R2s, np.array([1,1,1])/3, 'valid'),
+            temp = calc_cod(np.convolve(R2s, np.array([1, 1, 1]) / 3, 'valid'),
                             R2s[1:-1])
             
         if temp < 90:
@@ -525,50 +525,50 @@ def rsa_noise_ceiling(data,
         titleft = 36
         labelft = 24
 
-        ax['A'].hist(np.squeeze(mnS), facecolor='#442cb4', align = 'left')
-        ax['A'].set_ylabel('Frequency',fontsize=labelft)
-        ax['A'].set_title('Mean of Signal',fontsize=titleft)
-        ax['A'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        ax['A'].hist(np.squeeze(mnS), facecolor = '#442cb4', align = 'left')
+        ax['A'].set_ylabel('Frequency', fontsize = labelft)
+        ax['A'].set_title('Mean of Signal', fontsize = titleft)
+        ax['A'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
         mx = np.max(np.abs(cS.reshape(-1)))
         if mx == 0:
             mx = 1
 
-        im = ax['B'].imshow(cS, clim=(-mx, mx), cmap = 'viridis')
+        im = ax['B'].imshow(cS, clim = (-mx, mx), cmap = 'viridis')
         cb = plt.colorbar(im, ax = ax['B'])
-        cb.ax.tick_params(labelsize=labelft-2)
-        ax['B'].set_title('Covariance of Signal',fontsize=titleft)
-        ax['B'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        cb.ax.tick_params(labelsize = labelft - 2)
+        ax['B'].set_title('Covariance of Signal', fontsize = titleft)
+        ax['B'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
         mx = np.max(np.abs(cSb.reshape(-1)))
         if mx == 0:
             mx = 1
 
-        im = ax['C'].imshow(cSb, clim=(-mx, mx), cmap = 'viridis')
+        im = ax['C'].imshow(cSb, clim = (-mx, mx), cmap = 'viridis')
         cb = plt.colorbar(im, ax = ax['C'])
-        cb.ax.tick_params(labelsize=labelft-2)
-        ax['C'].set_title('Regularized and scaled',fontsize=titleft)
-        ax['C'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        cb.ax.tick_params(labelsize = labelft - 2)
+        ax['C'].set_title('Regularized and scaled', fontsize = titleft)
+        ax['C'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
-        ax['D'].hist(np.squeeze(mnN), facecolor='#442cb4', align = 'left')
-        ax['D'].set_ylabel('Frequency',fontsize=labelft)
-        ax['D'].set_title('Mean of Noise',fontsize=titleft)
-        ax['D'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        ax['D'].hist(np.squeeze(mnN), facecolor = '#442cb4', align = 'left')
+        ax['D'].set_ylabel('Frequency', fontsize = labelft)
+        ax['D'].set_title('Mean of Noise', fontsize = titleft)
+        ax['D'].tick_params(axis='both', which = 'major', labelsize = labelft - 2)
 
         mx = np.max(np.abs(cN.reshape(-1)))
         if mx == 0:
             mx = 1
 
-        im = ax['E'].imshow(cN, clim=(-mx, mx), cmap = 'viridis')
+        im = ax['E'].imshow(cN, clim = (-mx, mx), cmap = 'viridis')
         cb = plt.colorbar(im, ax = ax['E'])
-        cb.ax.tick_params(labelsize=labelft-2)
-        ax['E'].set_title('Covariance of Noise',fontsize=titleft)
-        ax['E'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        cb.ax.tick_params(labelsize = labelft - 2)
+        ax['E'].set_title('Covariance of Noise', fontsize = titleft)
+        ax['E'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
         ax['F'].hist(np.squeeze(ncsnr), facecolor='#442cb4', align = 'left')
-        ax['F'].set_ylabel('Frequency',fontsize=labelft)
-        ax['F'].set_title('Noise ceiling SNR',fontsize=titleft)
-        ax['F'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        ax['F'].set_ylabel('Frequency', fontsize = labelft)
+        ax['F'].set_title('Noise ceiling SNR', fontsize = titleft)
+        ax['F'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
         hs = []
         for sci in range(len(scs)):
@@ -579,8 +579,8 @@ def rsa_noise_ceiling(data,
         cm = plt.cm.viridis(np.linspace(0, 1, nlines))
 
         for sci in range(len(scs)):
-            md0 = np.median(modelsplitr[sci],axis=1) # 1 x n
-            se0 = (stats.iqr(modelsplitr[sci],axis=1)/2) / np.sqrt(modelsplitr.shape[2]) # 1 x n
+            md0 = np.median(modelsplitr[sci], axis = 1) # 1 x n
+            se0 = (stats.iqr(modelsplitr[sci], axis = 1) / 2) / np.sqrt(modelsplitr.shape[2]) # 1 x n
         
             if scs[sci] == sc:
                 lw0 = 8
@@ -589,28 +589,28 @@ def rsa_noise_ceiling(data,
                 lw0 = 4
                 mark0 = 'x'
 
-            ax['G'].plot(np.squeeze(splitnums), md0, f'{mark0}-',linewidth = lw0, color=cm[sci], markersize=16)
+            ax['G'].plot(np.squeeze(splitnums), md0, f'{mark0}-', linewidth = lw0, color = cm[sci], markersize = 16)
 
         md0 = np.median(datasplitr.reshape(-1, 1), axis = 1)
         sd0 = (stats.iqr(datasplitr.reshape(-1, 1), axis = 1)) / 2
         se0 = sd0 / np.sqrt(datasplitr.reshape(-1, 1).shape[1])
-        ax['G'].plot(np.squeeze(splitnums), md0, 'k-', linewidth = 8, zorder=100, marker = 'o', markersize=20, markeredgecolor = 'k', markerfacecolor = 'none')
-        ax['G'].set_xlim([np.min(splitnums)-1, np.max(splitnums)+1])
-        ax['G'].set_xlabel('Number of trials in each split',fontsize=labelft)
-        ax['G'].set_ylabel('Similarity (comparefun output)',fontsize=labelft)
+        ax['G'].plot(np.squeeze(splitnums), md0, 'k-', linewidth = 8, zorder = 100, marker = 'o', markersize = 20, markeredgecolor = 'k', markerfacecolor = 'none')
+        ax['G'].set_xlim([np.min(splitnums) - 1, np.max(splitnums) + 1])
+        ax['G'].set_xlabel('Number of trials in each split', fontsize = labelft)
+        ax['G'].set_ylabel('Similarity (comparefun output)', fontsize = labelft)
         
         if doexhaustive is 1:
-            ax['G'].set_title(f"Data (ALL sims); Model ({modelsplitr.shape[2]} sims); splitr={round(splitr,3)}",fontsize=titleft)
+            ax['G'].set_title(f"Data (ALL sims); Model ({modelsplitr.shape[2]} sims); splitr={round(splitr, 3)}",fontsize = titleft)
         else:
-            ax['G'].set_title(f"Data ({datasplitr.shape[1]} sims); Model ({modelsplitr.shape[2]} sims); splitr={round(splitr,3)}",fontsize=titleft)
-        ax['G'].tick_params(axis='both', which='major', labelsize=labelft-2)
+            ax['G'].set_title(f"Data ({datasplitr.shape[1]} sims); Model ({modelsplitr.shape[2]} sims); splitr={round(splitr, 3)}",fontsize = titleft)
+        ax['G'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
-        ax['H'].plot(scs, R2s, 'r-', marker = 'o', markeredgecolor='r', markerfacecolor='none', markersize=20)
+        ax['H'].plot(scs, R2s, 'r-', marker = 'o', markeredgecolor = 'r', markerfacecolor = 'none', markersize = 20)
         ax['H'].plot([sc, sc], [np.nanmin(R2s), np.nanmax(R2s)], 'k', linewidth = 8)
-        ax['H'].set_xlabel('Scaling factor',fontsize=labelft)
-        ax['H'].set_ylabel('R^2 between model and data (%)',fontsize=labelft)
-        ax['H'].set_title(f"rapprox={round(rapprox,2)}, sc = {round(sc,2)}, nc = {round(nc,3)}, +/- {round(stats.iqr(ncdist)/2/np.sqrt(len(ncdist)),3)}",fontsize=titleft)
-        ax['H'].tick_params(axis='both', which='major', labelsize=labelft-2)
+        ax['H'].set_xlabel('Scaling factor', fontsize = labelft)
+        ax['H'].set_ylabel('R^2 between model and data (%)', fontsize = labelft)
+        ax['H'].set_title(f"rapprox = {round(rapprox, 2)}, sc = {round(sc, 2)}, nc = {round(nc, 3)}, +/- {round(stats.iqr(ncdist) / 2 / np.sqrt(len(ncdist)), 3)}",fontsize = titleft)
+        ax['H'].tick_params(axis = 'both', which = 'major', labelsize = labelft - 2)
 
         if wantfig is not 1: 
             plt.savefig(wantfig, facecolor = 'white')

--- a/gsn/utilities.py
+++ b/gsn/utilities.py
@@ -41,3 +41,217 @@ def posrect(m,val=0):
     m[m<val] = val;
     
     return m
+
+def zerodiv(data1, data2, val=0, wantcaution=1):
+    """zerodiv(data1,data2,val,wantcaution)
+    Args:
+        <data1>,<data2> are matrices of the same size or either
+                        or both can be scalars.
+        <val> (optional) is the value to use when <data2> is 0.
+                        default: 0.
+        <wantcaution> (optional) is whether to perform special
+                        handling of weird cases (see below).
+                        default: 1.
+        calculate data1./data2 but use <val> when data2 is 0.
+        if <wantcaution>, then if the absolute value of one or
+                        more elements of data2 is less than 1e-5
+                        (but not exactly 0), we issue a warning
+                        and then treat these elements as if they
+                        are exactly 0.
+        if not <wantcaution>, then we do nothing special.
+
+    note some weird cases:
+    if either data1 or data2 is [], we return [].
+    NaNs in data1 and data2 are handled in the usual way.
+
+    """
+
+    # handle special case of data2 being scalar
+    if np.isscalar(data2):
+        if data2 == 0:
+            f = np.tile(val, data1.shape)
+        else:
+            if wantcaution and abs(data2) < 1e-5:
+                print(
+                    'warning: abs value of divisor is less than 1e-5.'
+                    'treating the divisor as 0.')
+                f = np.tile(val, data1.shape)
+            else:
+                f = data1/data2
+
+    else:
+        # do it
+        bad = data2 == 0
+        bad2 = abs(data2) < 1e-5
+        if wantcaution and np.any(bad2.ravel()) and ~bad.ravel():
+            print(
+                'warning: abs value of one or more divisors'
+                'less than 1e-5.treating them as 0.')
+
+        if wantcaution:
+            data2[bad2] = 1
+            f = data1/data2
+            f[bad2] = val
+        else:
+            data2[bad] = 1
+            f = data1/data2
+            f[bad] = val
+
+    return f
+
+
+def calc_cod(x, y, dim=None, wantgain=0, wantmeansub=1):
+    """Calculate the coefficient of determination
+
+    Args:
+        x ([type]): matrix with the same dimensions as y
+        y ([type]): matrix with the same dimensions as x
+        dim ([type]): is the dimension of interest
+        wantgain (int, optional): Defaults to 0. 0 means normal
+            1 means allow a gain to be applied to each case of <x>
+            to minimize the squared error with respect to <y>.
+            in this case, there cannot be any NaNs in <x> or <y>.
+            2 is like 1 except that gains are restricted to be non-negative.
+            so, if the gain that minimizes the squared error is negative,
+            we simply set the gain to be applied to be 0.
+            default: 0.
+        wantmeansub (int, optional): Defaults to 1.
+            0 means do not subtract any mean.  this makes it such that
+            the variance quantification is relative to 0.
+            1 means subtract the mean of each case of <y> from both
+            <x> and <y> before performing the calculation.  this makes
+            it such that the variance quantification
+            is relative to the mean of each case of <y>.
+            note that <wantgain> occurs before <wantmeansub>.
+            default: 1.
+
+    calculate the coefficient of determination (R^2) indicating
+    the percent variance in <y> that is explained by <x>.  this is achieved
+    by calculating 100*(1 - sum((y-x).^2) / sum(y.^2)).  note that
+    by default, we subtract the mean of each case of <y> from both <x>
+    and <y> before proceeding with the calculation.
+
+    the quantity is at most 100 but can be 0 or negative (unbounded).
+    note that this metric is sensitive to DC and scale and is not symmetric
+    (i.e. if you swap <x> and <y>, you may obtain different results).
+    it is therefore fundamentally different than Pearson's correlation
+    coefficient (see calccorrelation.m).
+
+    NaNs are handled gracefully (a NaN causes that data point to be ignored).
+
+    if there are no valid data points (i.e. all data points are
+    ignored because of NaNs), we return NaN for that case.
+
+    note some weird cases:
+    calccod([],[]) is []
+
+    history:
+    2013/08/18 - fix pernicious case where <x> is all zeros and <wantgain>
+    is 1 or 2.
+    2010/11/28 - add <wantgain>==2 case
+    2010/11/23 - changed the output range to percentages.  thus, the range
+    is (-Inf,100]. also, we removed the <wantr> input since
+    it was dumb.
+
+    example:
+    x = np.random.random(100)
+    calccod(x,x+0.1*np.random.random(100))
+    """
+
+    # input
+    if dim is None:
+        dim = np.argmax(x.shape)
+
+    # handle gain
+    if wantgain:
+        # to get the residuals, we want to do something like y-x*inv(x'*x)*x'*y
+        temp = 1/np.dot(x, x) * np.dot(x, y)
+        if wantgain == 2:
+            # if the gain was going to be negative, rectify it to 0.
+            temp[temp < 0] = 0
+        x = x * temp
+
+    # propagate NaNs (i.e. ignore invalid data points)
+    x[np.isnan(y)] = np.nan
+    y[np.isnan(x)] = np.nan
+
+    # handle mean subtraction
+    if wantmeansub:
+        mn = np.nanmean(y, axis=dim)
+        y = y - mn
+        x = x - mn
+
+    # finally, compute it
+    with np.errstate(divide='ignore', invalid='ignore'):
+        nom = np.nansum((y-x) ** 2, axis=dim)
+        denom = np.nansum((y**2), axis=dim)
+        f = np.nan_to_num(1 - (nom / denom))
+    return 100*f
+
+def calc_cod_stack(yhat, y):
+    """
+    [summary]
+
+    Args:
+        data ([type]): [description]
+        pred ([type]): [description]
+
+    Returns:
+        r2s: global r2s
+
+    """
+
+    numer = np.asarray(
+        [np.sum((a-b)**2, axis=0) for a, b in zip(yhat, y)]
+        ).sum(axis=0)
+    denom = np.asarray(
+        [np.sum(a**2, axis=0) for a in y]
+        ).sum(axis=0)
+
+    # calculate global R2
+
+    r2s = 100*(1 - zerodiv(
+        numer,
+        denom,
+        val=np.nan,
+        wantcaution=0
+        )
+    )
+
+    return r2s
+
+
+def nanreplace(m, val = 0, mode = 0):
+    """
+    function m = nanreplace(m,val,mode)
+    
+     <m> is a matrix
+     <val> (optional) is a scalar.  default: 0.
+     <mode> (optional) is
+       0 means replace all NaNs in <m> with <val>.
+       1 means if the first element of <m> is not finite (i.e. NaN, -Inf, Inf), fill entire matrix with <val>.
+       2 means if it is not true that all elements of <m> are finite and real, fill entire matrix with <val>.
+       3 means replace any non-finite value in <m> in <val>.
+       default: 0.
+    
+     example:
+     isequal(nanreplace([1 NaN],0),[1 0])
+     isequal(nanreplace([NaN 2 3],0,1),[0 0 0])
+     
+     """
+    
+    m = np.array(m)
+    
+    if mode == 0:
+        m[np.isnan(m)] = val
+    elif mode == 1:
+        if ~np.isfinite(m[0]):
+            m[:] = val
+    elif mode == 2:
+        if ~(np.all(np.logical_and(np.isreal(m.reshape(-1)), 
+                                   np.isfinite(m.reshape(-1))))):
+            m[:] = val
+    elif mode == 3:
+        m[~(np.isfinite(m))] = val
+        
+    return m

--- a/gsn/utilities.py
+++ b/gsn/utilities.py
@@ -188,39 +188,6 @@ def calc_cod(x, y, dim=None, wantgain=0, wantmeansub=1):
         f = np.nan_to_num(1 - (nom / denom))
     return 100*f
 
-def calc_cod_stack(yhat, y):
-    """
-    [summary]
-
-    Args:
-        data ([type]): [description]
-        pred ([type]): [description]
-
-    Returns:
-        r2s: global r2s
-
-    """
-
-    numer = np.asarray(
-        [np.sum((a-b)**2, axis=0) for a, b in zip(yhat, y)]
-        ).sum(axis=0)
-    denom = np.asarray(
-        [np.sum(a**2, axis=0) for a in y]
-        ).sum(axis=0)
-
-    # calculate global R2
-
-    r2s = 100*(1 - zerodiv(
-        numer,
-        denom,
-        val=np.nan,
-        wantcaution=0
-        )
-    )
-
-    return r2s
-
-
 def nanreplace(m, val = 0, mode = 0):
     """
     function m = nanreplace(m,val,mode)


### PR DESCRIPTION
- ported recent commits from matlab implementation to python - major revamp of rsa_noise_ceiling.py to incorporate recent updates to the algorithm (e.g. split half procedures, plotting)
- fixed bug in calc_shrunken_covariance that was causing incorrect shrinkage values to be selected if any negative log likelihood values were nan
- added relevant files to utilities.py
- i have tested the new implementation by verifying that it provides the same outputs as the matlab implementation given the same input data (up to a few decimal places- there is randomness built into the pipeline so outputs will not be numerically identical). plot outputs also look virtually identical. 
- this implementation has not been fully edge-cased and may be subject to bugs outside of the main use cases - should test further when possible.