### PR TITLE
fixed lingering python bugs after recent refactor (arose when ncsims > 0 and when wantfig = 1)

### DIFF
--- a/gsn/rsa_noise_ceiling.py
+++ b/gsn/rsa_noise_ceiling.py
@@ -116,6 +116,7 @@ def rsa_noise_ceiling(data, opt = None):
                 0 means the first estimate was already positive semi-definite.
 
     History:
+    - 2024/09/11 - misc. bug fixes
     - 2024/08/24 - add results['numiters']
     - 2024/01/05:
         (1) Major change to use the biconvex optimization procedure --

--- a/gsn/utilities.py
+++ b/gsn/utilities.py
@@ -49,7 +49,7 @@ def nanreplace(m, val=0, mode=0):
     Replace NaN or non-finite values in a matrix with a specified value.
 
     Parameters:
-    m (numpy.ndarray): A matrix.
+    m (numpy.ndarray or scalar): A matrix or scalar.
     val (optional, scalar): The value to replace NaNs with. Default is 0.
     mode (optional, int):
         0 means replace all NaNs in m with val.
@@ -65,6 +65,10 @@ def nanreplace(m, val=0, mode=0):
     assert np.array_equal(nanreplace(np.array([1, np.nan]), 0), np.array([1, 0]))
     assert np.array_equal(nanreplace(np.array([np.nan, 2, 3]), 0, 1), np.array([0, 0, 0]))
     """
+    
+    # Check if m is a scalar, and if so, wrap it in a numpy array
+    if np.isscalar(m):
+        m = np.array([m])
 
     if mode == 0:
         m[np.isnan(m)] = val
@@ -115,7 +119,7 @@ def zerodiv(x, y, val=0, wantcaution=1):
                 warnings.warn('abs value of divisor is less than 1e-5. we are treating the divisor as 0.')
                 return np.full(x.shape, val)
             else:
-                return x / y[:, np.newaxis]
+                return x / y # direct division by scalar y
     else:
         bad = y == 0
         bad2 = abs(y) < 1e-5  # see allzero.m


### PR DESCRIPTION
parts of the python pipeline had not been tested during the recent large-scale refactor. there were lingering bugs that only arose when I tried to run the noise ceiling monte carlo simulation procedure. 

these did not manifest earlier because:
- ncsims was set to 0 in perform_gsn.py to exclude the monte carlo sims, so when running the rsa noise ceiling procedure there were whole chunks of code that executed beyond the scope of example01
- wantfig was also disabled in perform_gsn.py, same story
- we didn't extensively test the pipeline previously, beyond ensuring that the python and matlab outputs matched for the example test case. 

the bugs are mostly of the sort that typically arise when porting from matlab to python, e.g. using the wrong value for "axis =" since numpy squeezes out dimensions of size 1 automatically, but matlab does not.  

I attempted to fix the bugs and tested the code in the following ways:
- I tested that the output of running perform_gsn on the example01 data is exactly the same as before (actually, I believe all the changes were in parts of the code that are unused during a default call to perform_gsn... otherwise we would have caught these bugs sooner)
- I tested that the rsa_noise_ceiling part of the library runs as a standalone function call, plots the figure correctly, etc. 
- I tried to compare the python and matlab outputs when calling rsa_noise_ceiling.py with default inputs on the example01 data, but there are many instances of random sampling in both pipelines so it's hard to test for numeric equivalence beyond ensuring that the results are in the same ballpark (they are...)


